### PR TITLE
Update filechoosers.kv

### DIFF
--- a/examples/demo/showcase/data/screens/filechoosers.kv
+++ b/examples/demo/showcase/data/screens/filechoosers.kv
@@ -20,5 +20,7 @@ ShowcaseScreen:
     FileChooser:
         id: filechooser
         
+        show_hidden: True
+        
         FileChooserIconLayout
         FileChooserListLayout


### PR DESCRIPTION
FileChooser: set the "show_hidden: True" or the FileChooser widget might crash on Windows, if specific open/hidden/system file or subdirectory exists on the target path. Usually e.g. C:\ does contain those type of files/directories.